### PR TITLE
Fix path to font in ship designer.

### DIFF
--- a/sidebar.cpp
+++ b/sidebar.cpp
@@ -142,8 +142,8 @@ void PlanetInspector::updateWidgets() {
 
 ShipDesigner::ShipDesigner(Game *game, Planet *sender, Planet *destination): sender(sender), destination(destination) {
     // Load the required fonts
-    body.loadFromFile("assets/fonts/Cabin-Regular.ttf");
-    header.loadFromFile("assets/fonts/Cabin-Bold.ttf");
+    body.loadFromFile("../assets/fonts/Cabin-Regular.ttf");
+    header.loadFromFile("../assets/fonts/Cabin-Bold.ttf");
 
     // Create and add the widgets
     title = TitleWidget(&header, "Ship Designer");


### PR DESCRIPTION
The ship designer was still looking `assets` instead of `../assets` since now we are using a `build` directory.
This was intruduced in e06c54587593006bc51233e5a2e0520cc1fe18f9